### PR TITLE
Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY package*.json ./
 
 RUN npm i glob rimraf
 
+RUN npm i -g @nestjs/cli
+
 RUN npm i --only=development
 
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
       - /usr/src/app/node_modules
     command: npm run start:debug
     restart: unless-stopped
-    environment:
-      MONGO_URL: mongodb
   mongodb:
     image: mongo:5.0.0
     container_name: server-mongodb
@@ -33,11 +31,6 @@ services:
       - nestjs-network
     ports:
       - 27017:27017
-    healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/test --quiet
-      interval: 30s
-      timeout: 10s
-      retries: 3
     restart: unless-stopped
   mongo-express:
     image: mongo-express
@@ -57,11 +50,6 @@ services:
       - nestjs-network
     ports:
       - 8081:8081
-    healthcheck:
-      test: wget --quiet --tries=3 --spider http://admin:admin123@localhost:8081 || exit 1
-      interval: 30s
-      timeout: 10s
-      retries: 3
     restart: unless-stopped
 volumes:
   mongodb-data: 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,18 @@
     "nestjs": "0.0.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "@nestjs/config": "^2.0.1",
+    "class-validator": "^0.13.2",
+    "class-transformer": "^0.5.1",
+    "bcrypt": "^5.0.1",
+    "@nestjs/jwt": "^8.0.1",
+    "@nestjs/passport": "^8.2.1",
+    "passport": "^0.5.3",
+    "passport-jwt": "^4.0.0",
+    "passport-local": "^1.0.0",
+    "@types/passport-jwt": "^3.0.6",
+    "@types/passport-local": "^1.0.34"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,17 +1,20 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ConfigModule } from '@nestjs/config';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { MongooseModule } from '@nestjs/mongoose';
-
-const url = process.env.MONGO_URL || 'localhost';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   controllers: [AppController],
   providers: [AppService],
   imports: [
+    ConfigModule.forRoot(),
     MongooseModule.forRoot(
-      `mongodb://${url}:27017?serverSelectionTimeoutMS=2000&authSource=admin`,
+      process.env.MONGO_URI,
     ),
+    AuthModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Body,
+  Controller,
+  Post,
+  Request,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
+
+import { AuthService } from './auth.service';
+import { AuthCredentialsDto } from './dto/auth-credentials.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private authService: AuthService) {}
+
+  @Post('/signup')
+  async signUp(
+    @Body(ValidationPipe) authCredentialsDto: AuthCredentialsDto
+  ): Promise<void> {
+    return await this.authService.signUp(authCredentialsDto);
+  }
+
+  @Post('/signin')
+  async signIn(@Request() req) {
+    return this.authService.signIn(req.body);
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,11 +18,11 @@ export class AuthController {
   async signUp(
     @Body(ValidationPipe) authCredentialsDto: AuthCredentialsDto
   ): Promise<any> {
-    const user = await this.authService.signUp(authCredentialsDto);
-    const token = await this.authService.signIn(user);
-    const sanitizedUser = this.authService.sanitizeUser(user);
+    const authUser = await this.authService.signUp(authCredentialsDto);
+    const token = await this.authService.signIn(authUser);
+    const user = this.authService.sanitizeUser(authUser);
 
-    return { sanitizedUser, token };
+    return { user, token };
   }
 
   @Post('/signin')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -17,8 +17,12 @@ export class AuthController {
   @Post('/signup')
   async signUp(
     @Body(ValidationPipe) authCredentialsDto: AuthCredentialsDto
-  ): Promise<void> {
-    return await this.authService.signUp(authCredentialsDto);
+  ): Promise<any> {
+    const user = await this.authService.signUp(authCredentialsDto);
+    const token = await this.authService.signIn(user);
+    const sanitizedUser = this.authService.sanitizeUser(user);
+
+    return { sanitizedUser, token };
   }
 
   @Post('/signin')

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MongooseModule } from '@nestjs/mongoose';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UserSchema } from 'src/auth/schemas/user.schema';
+import { LocalStrategy } from './strategies/local.strategy';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService, LocalStrategy],
+  exports: [AuthService],
+  imports: [
+    ConfigModule.forRoot(),
+    MongooseModule.forFeature([{ name: 'User', schema: UserSchema }]),
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '60s' },
+    }),
+  ],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, ConflictException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import * as bcrypt from 'bcrypt';
+import { Model } from 'mongoose';
+import { JwtService } from '@nestjs/jwt';
+
+import { AuthCredentialsDto } from './dto/auth-credentials.dto';
+import { User } from './interfaces/user.interface';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectModel('User') private userModel: Model<User>,
+    private jwtService: JwtService
+  ) {}
+
+  async signUp(authCredentialsDto: AuthCredentialsDto): Promise<void> {
+    const { email, password } = authCredentialsDto;
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = new this.userModel({ email, password: hashedPassword });
+
+    try {
+      await user.save();
+    } catch (error) {
+      if (error.code === 11000) {
+        throw new ConflictException('User already exists');
+      }
+      throw error;
+    }
+  }
+
+  async signIn(user: User) {
+    const payload = { email: user.email, sub: user._id };
+    return {
+      accessToken: this.jwtService.sign(payload),
+    };
+  }
+
+  async validateUser(email: string, pass: string): Promise<User> {
+    const user = await this.userModel.findOne({ email });
+
+    if (!user) {
+      return null;
+    }
+
+    const valid = await bcrypt.compare(pass, user.password);
+
+    if (valid) {
+      return user;
+    }
+
+    return null;
+  }
+}

--- a/src/auth/dto/auth-credentials.dto.ts
+++ b/src/auth/dto/auth-credentials.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, MaxLength, MinLength, IsEmail } from 'class-validator';
+
+export class AuthCredentialsDto {
+  @IsString()
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(8, { message: 'Password is too short (8 characters min)' })
+  @MaxLength(128, { message: 'Password is too long (128 characters max)' })
+  password: string;
+}

--- a/src/auth/interfaces/user.interface.ts
+++ b/src/auth/interfaces/user.interface.ts
@@ -1,0 +1,6 @@
+import { Document } from 'mongoose';
+
+export interface User extends Document {
+  readonly email: string;
+  readonly password: string;
+}

--- a/src/auth/schemas/user.schema.ts
+++ b/src/auth/schemas/user.schema.ts
@@ -1,0 +1,9 @@
+import * as mongoose from 'mongoose';
+
+export const UserSchema = new mongoose.Schema({
+  email: {
+    type: String,
+    unique: true,
+  },
+  password: String,
+})

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,0 +1,20 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-local';
+
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+  constructor(private authService: AuthService) {
+    super();
+  }
+
+  async validate(email: string, password: string): Promise<any> {
+    const user = await this.authService.validateUser(email, password);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+    return user;
+  }
+}


### PR DESCRIPTION
Add sign-in and sign-up features using JWT, Passport and bcrypt to hash passwords.

**Routes**
`/auth/signup`
`auth/signin`

Email and passwords fields must be passed in the body.

Later, the accesToken will be used as a Bearer in the Authorization header.

TODO: add local guard in sign-in route.

Obs: a .env file must be added containing two variables: MONGO_URI  and JWT_SECRET. Example: 

> MONGO_URI="mongodb://root:pass12345@mongodb:27017?serverSelectionTimeoutMS=2000&authSource=admin"
JWT_SECRET="eb5b6f14f2b63e08623f91bfbd77848d62164f6b733548142e5ed37f3e8ce876"

Closes #6 
Closes #7 